### PR TITLE
Fixed cuda pinning for cuda and pytorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 2f14c510a6e93f404c6ea357210615b3c15a71731f9dbd86f25434e34fb5a741
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win]
   # pytorch in conda-forge does not support CUDA 11.8 as of v2.5
   skip: true  # [cuda_compiler_version == "11.8"]
@@ -43,6 +43,7 @@ requirements:
     - scipy
     - libxcrypt               # [linux and py<39]
     {% if cuda_major >= 12 %}
+    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - cuda-driver-dev
     - cuda-cudart-dev
     - cuda-nvrtc-dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,8 @@ requirements:
     - setuptools
     - pytest-runner
     - scipy
-    - libxcrypt               # [linux and py<39]
     {% if cuda_major >= 12 %}
-    - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+    - cuda-version {{ cuda_compiler_version }}
     - cuda-driver-dev
     - cuda-cudart-dev
     - cuda-nvrtc-dev


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Currently the cuda and pytorch pins allow cuda versions to based on what's default. E.g. when building version:
```
linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13python3.10.____cpython
```
it ends up with deps like:
```
    cuda-cudart:                 12.8.90-h5888daf_1                   conda-forge
    cuda-cudart-dev:             12.8.90-h5888daf_1                   conda-forge
    pytorch:                     2.6.0-cuda126_mkl_py310_hb403307_302 conda-forge
```
which makes it incompatible with the very cuda 12.6 it's supposed to be using in this build, e.g.
```
$ conda create -n pt2.6-sparse-mismatch conda-forge::python=3.10 conda-forge::cuda-runtime=12.6 conda-forge::pytorch=2.6.0=cuda* conda-forge::pytorch_sparse --dry-run
...
   ├─ pytorch_sparse 0.6.18 would require
   │  └─ cuda-cudart >=12.8.57,<13.0a0 , which conflicts with any installable versions previously reported;
```

The deps should be (and is after this patch when testing locally):
```
    cuda-cudart:                 12.6.77-h5888daf_0                   conda-forge
    cuda-cudart-dev:             12.6.77-h5888daf_0                   conda-forge
    pytorch:                     2.6.0-cuda126_mkl_py310_hb403307_302 conda-forge
```